### PR TITLE
fix: resize images while exporting to fs format

### DIFF
--- a/core/src/main/java/studio/core/v1/utils/ImageConversion.java
+++ b/core/src/main/java/studio/core/v1/utils/ImageConversion.java
@@ -68,6 +68,41 @@ public class ImageConversion {
         }
     }
 
+    public static byte[] resizeAndCrop(BufferedImage img, int targetWidth, int targetHeight) throws IOException {
+        // BufferedImage img = ImageIO.read(new ByteArrayInputStream(data));
+        int width = img.getWidth();
+        int height = img.getHeight();
+
+        // Calculate the aspect ratio preserving scale factor
+        // double aspectRatio = (double) width / height;
+        double scaleFactor = Math.min((float) targetWidth / width, (float) targetHeight / height);
+
+        // Calculate the new dimensions
+        int newWidth = (int) (width * scaleFactor);
+        int newHeight = (int) (height * scaleFactor);
+
+        // Create a BufferedImage to hold the resized and cropped image
+        BufferedImage resizedImage = new BufferedImage(targetWidth, targetHeight, img.getType());
+        Graphics2D g = resizedImage.createGraphics();
+
+        // Set the drawing area in the center of the BufferedImage
+        int x = (targetWidth - newWidth) / 2;
+        int y = (targetHeight - newHeight) / 2;
+
+        // Draw the scaled image into the BufferedImage
+        g.drawImage(img, x, y, newWidth, newHeight, null);
+        g.dispose();
+
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            ImageIO.write(resizedImage, BITMAP_FORMAT, output);
+            if (output.size() == 0) {
+                throw new IOException("Failed to convert image");
+            }
+            return output.toByteArray();
+        }
+    }
+
+
     private static BufferedImage redrawImage(BufferedImage img) {
         BufferedImage redrawn = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_INT_RGB);
         Graphics2D g2d = redrawn.createGraphics();

--- a/core/src/main/java/studio/core/v1/utils/PackAssetsCompression.java
+++ b/core/src/main/java/studio/core/v1/utils/PackAssetsCompression.java
@@ -12,6 +12,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import java.awt.image.BufferedImage;
+
+import javax.imageio.ImageIO;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 
@@ -106,6 +109,13 @@ public class PackAssetsCompression {
         // Image
         processImageAssets(pack, ImageType.BMP, ThrowingFunction.unchecked(ia -> {
             byte[] imageData = ia.getRawData();
+            // resize image to 320x240
+            // we need to load the image to test its size
+            BufferedImage img = ImageIO.read(new ByteArrayInputStream(imageData));
+            if (img.getWidth() != 320 || img.getHeight() != 240) {
+                LOGGER.debug("Resizing image to 320x240");
+                imageData = ImageConversion.resizeAndCrop(img, 320, 240);
+            }
             // Convert to 4-bits depth / RLE encoding BMP
             if (ImageType.BMP != ia.getType() || imageData[28] != 0x04 || imageData[30] != 0x02) {
                 LOGGER.debug("Converting image asset into 4-bits/RLE BMP");


### PR DESCRIPTION
This ensure images are correctly resized for lunii when a package is transfered